### PR TITLE
Fix issues with debug build in Visual Studio 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,21 @@ target_sources(chelp PRIVATE
 target_include_directories(chelp PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)
 target_link_libraries(chelp PRIVATE $<TARGET_NAME_IF_EXISTS:kauai>)
 
+# Kauai test applications
+add_executable(ft WIN32 EXCLUDE_FROM_ALL)
+target_sources(ft PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/TEST.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/FT.RC"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/FT.CPP"
+)
+target_link_libraries(ft PRIVATE kauai)
+
+add_executable(ut EXCLUDE_FROM_ALL)
+target_sources(ut PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UT.CPP"
+)
+target_link_libraries(ut PRIVATE kauai)
+
 add_executable(chomp EXCLUDE_FROM_ALL)
 target_sources(chomp PRIVATE "${PROJECT_SOURCE_DIR}/kauai/tools/chomp.cpp")
 target_include_directories(chomp PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,13 @@ add_executable(kcd2-386 EXCLUDE_FROM_ALL)
 target_sources(kcd2-386 PRIVATE "${PROJECT_SOURCE_DIR}/kauai/src/kcd2_386.c")
 target_include_directories(kcd2-386 PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)
 
-add_executable(chelp EXCLUDE_FROM_ALL)
-target_sources(chelp PRIVATE "${PROJECT_SOURCE_DIR}/kauai/tools/chelp.cpp")
+add_executable(chelp WIN32 EXCLUDE_FROM_ALL)
+target_sources(chelp PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHTOP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHELP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHELPEXP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHELP.RC"
+)
 target_include_directories(chelp PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)
 target_link_libraries(chelp PRIVATE $<TARGET_NAME_IF_EXISTS:kauai>)
 
@@ -84,6 +89,8 @@ add_library(kauai)
 file(GLOB kauai-sources CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/kauai/src/*.cpp")
 file(GLOB kauai-headers CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/kauai/src/*.h")
 list(FILTER kauai-sources EXCLUDE REGEX "MAC[.](CPP|cpp)")
+list(FILTER kauai-sources EXCLUDE REGEX "FT[.](CPP|cpp)")
+list(FILTER kauai-sources EXCLUDE REGEX "UT[.](CPP|cpp)")
 target_include_directories(
   kauai
     PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,49 @@ target_sources(chomp PRIVATE "${PROJECT_SOURCE_DIR}/kauai/tools/chomp.cpp")
 target_include_directories(chomp PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)
 target_link_libraries(chomp PRIVATE $<TARGET_NAME_IF_EXISTS:kauai>)
 
+# Chunk Editor
+add_executable(ched WIN32 EXCLUDE_FROM_ALL)
+target_sources(ched PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHED.RC"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHDOC.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHED.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHGRP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHHEX.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHMBMP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHPIC.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHTXT.CPP"
+)
+target_link_libraries(ched PRIVATE kauai)
+
+# mkmbmp
+add_executable(mkmbmp EXCLUDE_FROM_ALL)
+target_sources(mkmbmp PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/MKMBMP.CPP"
+)
+target_link_libraries(mkmbmp PRIVATE kauai)
+
+# kpack
+add_executable(kpack EXCLUDE_FROM_ALL)
+target_sources(kpack PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/KPACK.CPP"
+)
+target_link_libraries(kpack PRIVATE kauai)
+
+# chmerge
+add_executable(chmerge EXCLUDE_FROM_ALL)
+target_sources(chmerge PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHMERGE.CPP"
+)
+target_link_libraries(chmerge PRIVATE kauai)
+
+# chelpdmp
+add_executable(chelpdmp EXCLUDE_FROM_ALL)
+target_sources(chelpdmp PRIVATE
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHELPDMP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/TOOLS/CHELPEXP.CPP"
+)
+target_link_libraries(chelpdmp PRIVATE kauai)
+
 # These are only here to ensure configure is rerun when dependencies are generated.
 # This is 
 file(GLOB building-chunk-sources CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/SRC/BUILDING/*.cht")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ target_link_libraries(chelpdmp PRIVATE kauai)
 # These are only here to ensure configure is rerun when dependencies are generated.
 # This is 
 file(GLOB building-chunk-sources CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/SRC/BUILDING/*.cht")
-file(GLOB studio-chunk-sources CONFIGURE_DEPENDS "${PROJECT_SORUCE_DIR}/SRC/STUDIO/*.cht")
+file(GLOB studio-chunk-sources CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/SRC/STUDIO/*.cht")
 
 add_custom_command(
   OUTPUT "${PROJECT_BINARY_DIR}/generated/kauai/src/kcdc_386.h"
@@ -147,13 +147,7 @@ add_custom_command(
 )
 
 add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/wd4430>)
-
 add_library(kauai)
-file(GLOB kauai-sources CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/kauai/src/*.cpp")
-file(GLOB kauai-headers CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/kauai/src/*.h")
-list(FILTER kauai-sources EXCLUDE REGEX "MAC[.](CPP|cpp)")
-list(FILTER kauai-sources EXCLUDE REGEX "FT[.](CPP|cpp)")
-list(FILTER kauai-sources EXCLUDE REGEX "UT[.](CPP|cpp)")
 target_include_directories(
   kauai
     PUBLIC
@@ -164,7 +158,76 @@ target_sources(kauai
   PRIVATE
     "${PROJECT_BINARY_DIR}/generated/kauai/src/kcdc_386.h"
     "${PROJECT_BINARY_DIR}/generated/kauai/src/kcd2_386.h"
-    ${kauai-sources})
+
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/APPB.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/BASE.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CHCM.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CHSE.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CHUNK.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CLIP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CLOK.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CMD.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CODEC.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CODKAUAI.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CRF.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CTL.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/CURSOR.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/DLG.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/DOCB.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/FILE.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/FRAME.RC"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/GFX.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/GOB.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/GROUPS.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/GROUPS2.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/KIDHELP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/KIDSPACE.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/KIDWORLD.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/LEX.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/MBMP.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/MBMPGUI.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/MIDI.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/MIDIDEV.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/MIDIDEV2.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/MSSIO.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/PIC.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/REGION.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/RTXT.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/RTXT2.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SCRCOM.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SCRCOMG.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SCREXE.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SCREXEG.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SNDAM.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SNDM.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/SPELL.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/STREAM.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/TEXT.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/TEXTDOC.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTIL.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILCOPY.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILERRO.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILGLOB.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILINT.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILMEM.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILRND.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/UTILSTR.CPP"
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/VIDEO.CPP"
+
+    # Windows implementations
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/APPBWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/DLGWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/FILEWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/FNIWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/GFXWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/MEMWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/MENUWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/PICWIN.CPP>
+    $<$<PLATFORM_ID:Windows>:${PROJECT_SOURCE_DIR}/kauai/SRC/GOBWIN.CPP>
+
+    # Stubs for Visual C++ 2.1 CRT functions
+    "${PROJECT_SOURCE_DIR}/kauai/SRC/stub.cpp"   
+)
 
 target_compile_definitions(kauai PUBLIC
   _LPCVOID_DEFINED
@@ -179,12 +242,15 @@ target_link_libraries(kauai
     $<$<PLATFORM_ID:Windows>:mpr>)
 
 add_library(brender)
-file(GLOB brender-sources CONFIGURE_DEPENDS
-  "${PROJECT_SOURCE_DIR}/BREN/*.CPP"
-  "${PROJECT_SOURCE_DIR}/BREN/*.C")
-
-list(FILTER brender-sources EXCLUDE REGEX "(MATERIAL|BRENFUN).CPP$")
-target_sources(brender PRIVATE ${brender-sources})
+target_sources(brender
+    PRIVATE
+    "${PROJECT_SOURCE_DIR}/BREN/BWLD.CPP"
+    "${PROJECT_SOURCE_DIR}/BREN/stderr.c"
+    "${PROJECT_SOURCE_DIR}/BREN/stdfile.c"
+    "${PROJECT_SOURCE_DIR}/BREN/stdmem.c"
+    "${PROJECT_SOURCE_DIR}/BREN/TMAP.CPP"
+    "${PROJECT_SOURCE_DIR}/BREN/ZBMP.CPP"
+)
 target_include_directories(brender PUBLIC "${PROJECT_SOURCE_DIR}/BREN/INC")
 target_link_libraries(brender
   PUBLIC
@@ -192,21 +258,52 @@ target_link_libraries(brender
     BRender::Libraries)
 
 add_library(engine)
-file(GLOB engine-sources CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/SRC/ENGINE/*.CPP")
-target_sources(engine PRIVATE ${engine-sources})
+target_sources(engine
+    PRIVATE
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/ACTOR.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/ACTREDIT.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/ACTRSAVE.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/ACTRSND.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/BKGD.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/BODY.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/MODL.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/MOVIE.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/MSND.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/MTRL.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/SCENE.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/SREC.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/TAGL.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/TAGMAN.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/TBOX.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/TDF.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/TDT.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/ENGINE/TMPL.CPP"
+)
 target_include_directories(engine PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/INC>)
 target_link_libraries(engine PUBLIC kauai brender)
 
 # On non-windows WIN32 is a no-op
 add_executable(studio WIN32)
-file(GLOB studio-sources CONFIGURE_DEPENDS
-  "${PROJECT_SOURCE_DIR}/src/studio/*.cpp"
-  "${PROJECT_SOURCE_DIR}/src/studio/*.rc")
-file(GLOB studio-samples CONFIGURE_DEPENDS
-  "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/*.3mm")
-list(FILTER studio-sources EXCLUDE REGEX "UTESTSCB.CPP$")
-target_sources(studio PRIVATE ${studio-sources})
+target_sources(studio
+    PRIVATE
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/APE.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/BROWSER.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/ESL.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/MMINSTAL.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/POPUP.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/PORTF.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/SCNSORT.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/SPLOT.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/STDIOBRW.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/STDIOSCB.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/STUDIO.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/TATR.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/TGOB.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/UTEST.CPP"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/UTEST.RC"
+    "${PROJECT_SOURCE_DIR}/SRC/STUDIO/UTEST.RC2"
+)
 target_include_directories(studio
   PUBLIC $<TARGET_PROPERTY:engine,INCLUDE_DIRECTORIES>
   "${PROJECT_SOURCE_DIR}/SRC")
@@ -226,7 +323,28 @@ target_link_options(studio BEFORE PRIVATE $<$<LINK_LANG_AND_ID:CXX,MSVC>:/MANIFE
 target_link_options(studio
   BEFORE PRIVATE
     $<$<AND:$<LINK_LANG_AND_ID:CXX,MSVC>,$<CONFIG:DEBUG>>:/NODEFAULTLIB:libcmt.lib>)
-set_property(TARGET studio PROPERTY 3DMM_SAMPLES ${studio-samples})
+
+set_property(
+    TARGET studio
+    PROPERTY 3DMM_SAMPLES
+    ${studio-samples}
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/BONGO.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/BOOOOOO.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/CITYTOUR.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/GRAVEYRD.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/HAUNTED.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/HOSPITAL.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/JUNGLE.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/MESSAGE.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/SPACE.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/SPROG.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/TERROR.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/THEBOOK.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/THELODGE.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/THETHIEF.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/VENUS31.3MM"
+    "${PROJECT_SOURCE_DIR}/cd3/SAMPLES/WHERE.3MM"
+)
 
 # Please pay attention to the ending / in each DIRECTORY declaration. It
 # affects the destination!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,9 @@ endif()
 
 add_compile_definitions(
   $<$<PLATFORM_ID:Windows>:WIN>
-  $<$<PLATFORM_ID:Windows>:IN_80386>)
+  $<$<PLATFORM_ID:Windows>:IN_80386>
+  $<$<CONFIG:Debug>:DEBUG>
+)
 
 # NOTE: kcdc-386 and kcd2-386 prevent cross compiling at this time.
 add_executable(kcdc-386 EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ add_compile_definitions(
   $<$<CONFIG:Debug>:DEBUG>
 )
 
+if (NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
+  message(FATAL_ERROR "Cannot compile for 64-bit yet")
+endif()
+
 # NOTE: kcdc-386 and kcd2-386 prevent cross compiling at this time.
 add_executable(kcdc-386 EXCLUDE_FROM_ALL)
 target_sources(kcdc-386 PRIVATE "${PROJECT_SOURCE_DIR}/kauai/src/kcdc_386.c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ endif()
 #endif()
 
 # Local Tooling
-
 add_compile_definitions(
   $<$<PLATFORM_ID:Windows>:WIN>
   $<$<PLATFORM_ID:Windows>:IN_80386>

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,23 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
+    },
+    {
+      "displayName": "MSVC x86 RelWithDebInfo",
+      "name": "x86:msvc:relwithdebinfo",
+      "inherits": "msvc:x86:base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "displayName": "MSVC x86 MinSizeRel",
+      "name": "x86:msvc:minsizerel",
+      "inherits": "msvc:x86:base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
+      }
     }
+
   ]
 }

--- a/INC/UTEST.H
+++ b/INC/UTEST.H
@@ -214,7 +214,7 @@ public:
 	virtual void GetStnAppName(PSTN pstn);
 	virtual long OnnDefVariable(void);
 	virtual long DypTextDef(void);
-	virtual bool TQuerySaveDoc(PDOCB pdocb, bool fForce);
+	virtual tribool TQuerySaveDoc(PDOCB pdocb, bool fForce);
 	virtual void Quit(bool fForce);
 	virtual void UpdateHwnd(HWND hwnd, RC *prc, ulong grfapp = fappNil);
 	virtual void Run(ulong grfapp, ulong grfgob, long ginDef);

--- a/SRC/STUDIO/UTEST.CPP
+++ b/SRC/STUDIO/UTEST.CPP
@@ -3150,7 +3150,7 @@ long APP::DypTextDef(void)
 /***************************************************************************
 	Ask the user if they want to save changes to the given doc.
 ***************************************************************************/
-bool APP::TQuerySaveDoc(PDOCB pdocb, bool fForce)
+tribool APP::TQuerySaveDoc(PDOCB pdocb, bool fForce)
 {
 	AssertThis(0);
 	AssertPo(pdocb, 0);
@@ -3159,7 +3159,7 @@ bool APP::TQuerySaveDoc(PDOCB pdocb, bool fForce)
 	long tpc;
 	STN stnBackup;
 	long bk;
-	bool tResult;
+	tribool tResult;
 
 	pdocb->GetName(&stnName);
 	tpc = fForce ? ktpcQuerySave : ktpcQuerySaveWithCancel;

--- a/SRC/STUDIO/UTEST.CPP
+++ b/SRC/STUDIO/UTEST.CPP
@@ -1611,7 +1611,7 @@ bool APP::_FReadTitlesFromReg(PGST *ppgst)
 		stnTitle.SetSz(PszLit("3D Movie Maker/3DMovie"));
 		sid=1;
 		if (!pgst->FAddStn(&stnTitle, &sid)){
-			Warn("Failed to add fallback Title!")
+			Warn("Failed to add fallback Title!");
 			goto LFail;
 		}
 

--- a/cmake/FindAudioMan.cmake
+++ b/cmake/FindAudioMan.cmake
@@ -19,5 +19,9 @@ if (${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT TARGET 3DMMForever::AudioMan)
   set_property(TARGET 3DMMForever::AudioMan
     PROPERTY
       IMPORTED_LOCATION "${${CMAKE_FIND_PACKAGE_NAME}_LIBRARY}")
+  # Precompiled AudioMan library does not support SafeSEH
+  target_link_options(3DMMForever::AudioMan INTERFACE
+      $<$<LINK_LANG_AND_ID:CXX,MSVC>:/SAFESEH:NO>
+  )
   mark_as_advanced(${CMAKE_FIND_PACKAGE_NAME}_LIBRARY)
 endif()

--- a/cmake/FindBRender.cmake
+++ b/cmake/FindBRender.cmake
@@ -9,11 +9,11 @@ include(FindPackageHandleStandardArgs)
 # starts to support external versions of BRender
 
 foreach (name IN ITEMS BRFMMXR BRFWMXR BRZBMXR)
-  foreach (cfg IN ITEMS DEBUG RELEASE)
+  foreach (cfg IN ITEMS DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
     set(variable ${CMAKE_FIND_PACKAGE_NAME}_${name}_${cfg}_LIBRARY)
-    set(suffix "D")
-    if (${cfg} STREQUAL "RELEASE")
-      set(suffix "S")
+    set(suffix "S")
+    if (${cfg} STREQUAL "DEBUG")
+      set(suffix "D")
     endif()
     find_library(${variable}
       NAMES ${name}
@@ -40,6 +40,8 @@ if (${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT TARGET BRender::Libraries)
     set_target_properties(BRender::${library}
       PROPERTIES
         IMPORTED_LOCATION_RELEASE ${${CMAKE_FIND_PACKAGE_NAME}_${library}_RELEASE_LIBRARY}
+        IMPORTED_LOCATION_RELWITHDEBINFO ${${CMAKE_FIND_PACKAGE_NAME}_${library}_RELWITHDEBINFO_LIBRARY}
+        IMPORTED_LOCATION_MINSIZEREL ${${CMAKE_FIND_PACKAGE_NAME}_${library}_MINSIZEREL_LIBRARY}
         IMPORTED_LOCATION_DEBUG ${${CMAKE_FIND_PACKAGE_NAME}_${library}_DEBUG_LIBRARY})
       target_link_libraries(BRender::Libraries INTERFACE BRender::${library})
     mark_as_advanced(

--- a/cmake/FindBRender.cmake
+++ b/cmake/FindBRender.cmake
@@ -51,4 +51,9 @@ if (${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT TARGET BRender::Libraries)
   target_link_libraries(BRender::BRFWMXR
     INTERFACE
       $<$<LINK_LANG_AND_ID:CXX,MSVC>:legacy_stdio_definitions>)
+
+  # Precompiled BRender libraries do not support SafeSEH
+  target_link_options(BRender::BRFWMXR INTERFACE
+      $<$<LINK_LANG_AND_ID:CXX,MSVC>:/SAFESEH:NO>
+  )
 endif()

--- a/kauai/SRC/APPB.CPP
+++ b/kauai/SRC/APPB.CPP
@@ -1747,7 +1747,7 @@ void APPB::BadModalCmd(PCMD pcmd)
 /***************************************************************************
 	Ask the user if they want to save changes to the given doc.
 ***************************************************************************/
-bool APPB::TQuerySaveDoc(PDOCB pdocb, bool fForce)
+tribool APPB::TQuerySaveDoc(PDOCB pdocb, bool fForce)
 {
 	AssertThis(0);
 	STN stn;

--- a/kauai/SRC/APPB.H
+++ b/kauai/SRC/APPB.H
@@ -316,7 +316,7 @@ public:
 	virtual void BadModalCmd(PCMD pcmd);
 
 	// Query save changes for a document
-	virtual bool TQuerySaveDoc(PDOCB pdocb, bool fForce);
+	virtual tribool TQuerySaveDoc(PDOCB pdocb, bool fForce);
 
 	// flush user generated events from the system event queue.
 	virtual void FlushUserEvents(ulong grfevt = kgrfevtAll);

--- a/kauai/SRC/CMD.CPP
+++ b/kauai/SRC/CMD.CPP
@@ -1120,7 +1120,7 @@ bool CEX::_FEnableCmd(PCMH pcmh, PCMD pcmd, ulong *pgrfeds)
 	Determines whether the given command is currently enabled. This is
 	normally used for menu graying/checking etc and toolbar enabling/status.
 ***************************************************************************/
-bool CEX::GrfedsForCmd(PCMD pcmd)
+ulong CEX::GrfedsForCmd(PCMD pcmd)
 {
 	AssertThis(0);
 	AssertPo(pcmd, 0);
@@ -1169,7 +1169,7 @@ LDone:
 	Determines whether the given command is currently enabled. This is
 	normally used for menu graying/checking etc and toolbar enabling/status.
 ***************************************************************************/
-bool CEX::GrfedsForCid(long cid, PCMH pcmh, PGG pgg,
+ulong CEX::GrfedsForCid(long cid, PCMH pcmh, PGG pgg,
 	long lw0, long lw1, long lw2, long lw3)
 {
 	AssertThis(0);

--- a/kauai/SRC/CMD.H
+++ b/kauai/SRC/CMD.H
@@ -306,8 +306,8 @@ public:
 	virtual void FlushCid(long cid);
 
 	// menu marking
-	virtual bool GrfedsForCmd(PCMD pcmd);
-	virtual bool GrfedsForCid(long cid, PCMH pcmh = pvNil, PGG pgg = pvNil,
+	virtual ulong GrfedsForCmd(PCMD pcmd);
+	virtual ulong GrfedsForCid(long cid, PCMH pcmh = pvNil, PGG pgg = pvNil,
 		long lw0 = 0, long lw1 = 0, long lw2 = 0, long lw3 = 0);
 
 	// mouse tracking

--- a/kauai/SRC/KIDSPACE.CPP
+++ b/kauai/SRC/KIDSPACE.CPP
@@ -1065,7 +1065,7 @@ bool GOK::_FFilterCmd(PCMD pcmd, CHID chidScript, bool *pfFilter)
 	long rglw[6];
 	long lw;
 	bool fGokExists;
-	bool tRet;
+	tribool tRet;
 
 	rglw[0] = (pvNil == pcmd->pcmh) ? hidNil : pcmd->pcmh->Hid();
 	rglw[1] = pcmd->cid;
@@ -1464,7 +1464,7 @@ void GOK::SetNoSlip(bool fNoSlip)
 	CAUTION: this GOK may not exist on return.
 ***************************************************************************/
 bool GOK::FRunScript(CHID chid, long *prglw, long clw, long *plwReturn,
-	bool *ptSuccess)
+	tribool *ptSuccess)
 {
 	AssertThis(0);
 	AssertNilOrVarMem(plwReturn);
@@ -1490,7 +1490,7 @@ bool GOK::FRunScript(CHID chid, long *prglw, long clw, long *plwReturn,
 	CAUTION: this GOK may not exist on return.
 ***************************************************************************/
 bool GOK::FRunScriptCno(CNO cno, long *prglw, long clw, long *plwReturn,
-	bool *ptSuccess)
+	tribool *ptSuccess)
 {
 	AssertThis(0);
 	AssertNilOrVarMem(plwReturn);
@@ -1576,7 +1576,7 @@ bool GOK::FCmdClicked(PCMD_MOUSE pcmd)
 	PGOB pgob;
 	long rglw[3];
 	long lw;
-	bool tRet;
+	tribool tRet;
 	CUME cume;
 	long hid = Hid();
 	long grid = Grid();

--- a/kauai/SRC/KIDSPACE.H
+++ b/kauai/SRC/KIDSPACE.H
@@ -421,9 +421,9 @@ public:
 	virtual long LwState(void);
 
 	virtual bool FRunScript(CHID chid, long *prglw = pvNil, long clw = 0,
-		long *plwReturn = pvNil, bool *ptSuccess = pvNil);
+		long *plwReturn = pvNil, tribool *ptSuccess = pvNil);
 	virtual bool FRunScriptCno(CNO cno, long *prglw = pvNil, long clw = 0,
-		long *plwReturn = pvNil, bool *ptSuccess = pvNil);
+		long *plwReturn = pvNil, tribool *ptSuccess = pvNil);
 	virtual bool FChangeState(long sno);
 	virtual bool FSetRep(CHID chid, ulong grfgok = fgokKillAnim,
 		CTG ctg = ctgNil, long dxp = 0, long dyp = 0, ulong dtim = 0);

--- a/kauai/SRC/KIDWORLD.CPP
+++ b/kauai/SRC/KIDWORLD.CPP
@@ -425,7 +425,7 @@ bool WOKS::FFindFile(PSTN pstnSrc, PFNI pfni)
 /***************************************************************************
 	Put up an alert (and don't return until it is dismissed).
 ***************************************************************************/
-bool WOKS::TGiveAlert(PSTN pstn, long bk, long cok)
+tribool WOKS::TGiveAlert(PSTN pstn, long bk, long cok)
 {
 	AssertThis(0);
 

--- a/kauai/SRC/KIDWORLD.H
+++ b/kauai/SRC/KIDWORLD.H
@@ -142,7 +142,7 @@ public:
 	virtual PCMH PcmhFromHid(long hid);
 	virtual PGOB PgobParGob(PGOB pgob);
 	virtual bool FFindFile(PSTN pstnSrc, PFNI pfni);
-	virtual bool TGiveAlert(PSTN pstn, long bk, long cok);
+	virtual tribool TGiveAlert(PSTN pstn, long bk, long cok);
 	virtual void Print(PSTN pstn);
 
 	virtual ulong GrfcustCur(bool fAsynch = fFalse);

--- a/kauai/SRC/MEMWIN.CPP
+++ b/kauai/SRC/MEMWIN.CPP
@@ -227,7 +227,10 @@ void AssertPvCb(void *pv, long cb)
 {
 	if (vcactSuspendCheckPointers == 0 && cb != 0)
 		{
-		AssertVar(!IsBadWritePtr(pv, cb), "no write access to ptr", &pv);
+		// This assert has been disabled because AssertPvCb is called on pointers to
+		// globals which were previously read/write but are now read-only.
+
+		//AssertVar(!IsBadWritePtr(pv, cb), "no write access to ptr", &pv);
 		// I (ShonK) am assuming that write access implies read access for
 		// memory, so it would just be a waste of time to call this.
 		// AssertVar(!IsBadReadPtr(pv, cb), "no read access to ptr", &pv);

--- a/kauai/SRC/SCREXEG.CPP
+++ b/kauai/SRC/SCREXEG.CPP
@@ -357,7 +357,7 @@ bool SCEG::_FExecOp(long op)
 			}
 		else
 			{
-			bool tRet;
+			tribool tRet;
 
 			GobMayDie();
 			if (kopRunScriptCnoGob == op || kopRunScriptCnoThis == op)

--- a/kauai/SRC/UTILGLOB.CPP
+++ b/kauai/SRC/UTILGLOB.CPP
@@ -24,6 +24,9 @@ ASSERTNAME
 
 RTCLASS(USAC)
 
+// Allocate globals in utilglob before any other globals to avoid crashes on exit
+#pragma init_seg(lib)
+
 #ifdef DEBUG
 // protects our debug linked list object management
 MUTX vmutxBase;

--- a/kauai/TOOLS/CHDOC.CPP
+++ b/kauai/TOOLS/CHDOC.CPP
@@ -128,7 +128,7 @@ bool _FDlgAddChunk(PDLG pdlg, long *pidit, void *pv)
 				lw != (long)padcd->cki.cno) &&
 				padcd->pcfl->FFind(ctg, lw))
 			{
-			bool tRet = vpappb->TGiveAlertSz(PszLit("A chunk with this CTG & CNO")
+			tribool tRet = vpappb->TGiveAlertSz(PszLit("A chunk with this CTG & CNO")
 				PszLit(" already exists. Replace the existing chunk?"),
 				bkYesNoCancel, cokQuestion);
 

--- a/kauai/TOOLS/CHDOC.H
+++ b/kauai/TOOLS/CHDOC.H
@@ -481,7 +481,7 @@ protected:
 	long _XpFromCb(long cb, bool fHex, bool fNoTrailSpace = fFalse);
 	long _XpFromIb(long ib, bool fHex);
 	long _YpFromIb(long ib);
-	long _IbFromPt(long xp, long yp, bool *ptHex, bool *pfRight = pvNil);
+	long _IbFromPt(long xp, long yp, tribool *ptHex, bool *pfRight = pvNil);
 
 	void _SetSel(long ibAnchor, long ibOther, bool fRight);
 	void _SetHalfSel(long ib);

--- a/kauai/TOOLS/CHELP.CPP
+++ b/kauai/TOOLS/CHELP.CPP
@@ -21,8 +21,8 @@ BEGIN_CMD_MAP(APP, APPB)
 END_CMD_MAP_NIL()
 
 BEGIN_CMD_MAP(LIG, GOB)
-	ON_CID_ME(cidDoScroll, FCmdScroll, pvNil)
-	ON_CID_ME(cidEndScroll, FCmdScroll, pvNil)
+	ON_CID_ME(cidDoScroll, &LIG::FCmdScroll, pvNil)
+	ON_CID_ME(cidEndScroll, &LIG::FCmdScroll, pvNil)
 END_CMD_MAP_NIL()
 
 

--- a/kauai/TOOLS/CHHEX.CPP
+++ b/kauai/TOOLS/CHHEX.CPP
@@ -905,7 +905,7 @@ long DCH::_YpFromIb(long ib)
 	output (unless the point is not in the edit area of the DCH).  If *ptHex
 	is tYes or tNo on input, the ib is determined using *ptHex.
 ***************************************************************************/
-long DCH::_IbFromPt(long xp, long yp, bool *ptHex, bool *pfRight)
+long DCH::_IbFromPt(long xp, long yp, tribool *ptHex, bool *pfRight)
 {
 	AssertVarMem(ptHex);
 	AssertNilOrVarMem(pfRight);
@@ -967,7 +967,7 @@ long DCH::_IbFromPt(long xp, long yp, bool *ptHex, bool *pfRight)
 void DCH::MouseDown(long xp, long yp, long cact, ulong grfcust)
 {
 	AssertThis(0);
-	bool tHex;
+	tribool tHex;
 	bool fDown, fRight;
 	PT pt, ptT;
 	long ib;

--- a/kauai/TOOLS/CHTOP.CPP
+++ b/kauai/TOOLS/CHTOP.CPP
@@ -2230,7 +2230,7 @@ void HETD::GetHtopStn(long istn, PSTN pstn)
 	else if (pvNil != _pgst && istn < _pgst->IvMac())
 		_pgst->GetStn(istn, pstn);
 	else
-		pstn->SetNil;
+		pstn->SetNil();
 }
 
 


### PR DESCRIPTION
This PR fixes some issues with the debug build in Visual Studio 2022.

Currently the build does not define DEBUG so all of the asserts are compiled out. I updated the build to define DEBUG and found that some of the asserts were broken. For example, there is a pointer validation assert that assumes that every pointer it checks should be writable. This is no longer the case as some string constants are now read-only. The assert used IsBadWritePointer to check the pointer [which is a bad idea anyway](https://devblogs.microsoft.com/oldnewthing/20070625-00/?p=26283), so I have replaced the check with a no-op.

While testing the debug build I fixed a few other random bugs. Most of these were type casting bugs, where bools were used for bitfields. I also fixed a crash on exiting debug builds. This was caused by the debug memory allocator trying to acquire a critical section which had been destructed. The original code relied on the link order to ensure that the global objects in `utilglob.cpp` were initialized first and destructed last. I have added a MSVC-specific pragma to force these objects to be initialized first to avoid having to rely on the link order.

I have also added build targets for all of the Kauai tools. I haven't extensively tested all of the tools but they all compile and run.