### PR TITLE
Enable compilation with Docker Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+
+RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended `
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
+    --remove Microsoft.VisualStudio.Component.Windows81SDK `
+ || IF "%ERRORLEVEL%"=="3010" EXIT 0s
+
+RUN rmdir /S /Q C:\\TEMP
+
+RUN setx /M PATH "%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin"
+RUN setx /M PATH "%PATH%;C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+
+SHELL ["powershell"]
+
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
+
+RUN Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+RUN Install-Module -Name VCVars -Force
+RUN pushvc (invoke-vcvars -TargetArch x86 -HostArch AMD64)
+RUN choco install ninja -y
+
+ENTRYPOINT [ "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat", "&&", "cmd.exe" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  3dmmforever-build:
+    image: 3dmmforever-build
+    container_name: 3dmmforever-build
+    build: .
+    volumes:
+      - .:C:\3d
+    working_dir: C:\3d
+    command: >
+            C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\Common7\\Tools\\VsDevCmd.bat &&
+            cmake --preset x86:msvc:debug &&
+            cmake --build build &&
+            cmake --install build
+    


### PR DESCRIPTION
This PR allows us to compile the project with docker:

The image is built with the following:
* Visual Studio Build Tools 2022 (with VCTools and CMake)
* VCVars
* Ninja
* Chocolatey

To compile 3DMMForever inside a docker-container do this:
 * Install docker and docker-compose
 * Enable Windows Containers
 * Go to the root directory of this project and execute: `docker-compose up`
 
This will create an image with the name `3dmmforever-build` and compile whatever you have on the root directory.

Couple of things to point out:
 * We can add compilation to a GitHub actions workflow (so everytime the main branch is merged it creates a new release with a zip of dist/)
 * I recommend that the docker image is stored privately on this organization's registry to be used in the workflow instead of creating and downloading the windows servercore image every time.
 * Due to Microsoft's licensing we are not allowed to publish this image publicly on dockerhub etc because it has the Visual Studio Build Tools included.

