### PR TITLE
prepared higher warning level and forces more standard conformity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 set(CMAKE_CXX_STANDARD 14)
 
+if(MSVC)
+  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+endif()
+
 include(CMakeDependentOption)
 include(TargetChompSources)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ set(CMAKE_CXX_STANDARD 14)
 
 if(MSVC)
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
-  #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+  
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
+  # permissive forces C++14 const char* as default for literals
+  # this flag re-enables the auto-conversion for the microsoft compiler
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:strictStrings-")
 endif()
 
 include(CMakeDependentOption)

--- a/kauai/SRC/BASE.H
+++ b/kauai/SRC/BASE.H
@@ -175,7 +175,7 @@ inline void ResumeAssertValid(void)
     void AssertValid(ulong grf);
 #define NOCOPY(cls)                                                                                                    \
   private:                                                                                                             \
-    cls &cls::operator=(cls &robj)                                                                                     \
+    cls &operator=(cls &robj)                                                                                     \
     {                                                                                                                  \
         __AssertOnCopy();                                                                                              \
         return *this;                                                                                                  \

--- a/kauai/SRC/CHUNK.H
+++ b/kauai/SRC/CHUNK.H
@@ -119,7 +119,7 @@ class CFL : public CFL_PAR
     CFL(void);
     ~CFL(void);
 
-    static ulong CFL::_GrffilFromGrfcfl(ulong grfcfl);
+    static ulong _GrffilFromGrfcfl(ulong grfcfl);
 
     bool _FReadIndex(void);
     tribool _TValidIndex(void);

--- a/kauai/SRC/CLIP.H
+++ b/kauai/SRC/CLIP.H
@@ -43,7 +43,7 @@ class CLIP : public CLIP_PAR
     void _EnsureDoc();
     void _ExportCur(void);
     void _ImportCur(void);
-    bool CLIP::_FImportFormat(long clfm, void *pv = pvNil, long cb = 0, PDOCB *ppdocb = pvNil, bool *pfDelay = pvNil);
+    bool _FImportFormat(long clfm, void *pv = pvNil, long cb = 0, PDOCB *ppdocb = pvNil, bool *pfDelay = pvNil);
 
   public:
     CLIP(void);

--- a/kauai/SRC/GROUPS.H
+++ b/kauai/SRC/GROUPS.H
@@ -52,7 +52,7 @@ class GRPB : public GRPB_PAR
     HQ _hqData1;
     HQ _hqData2;
 
-    bool GRPB::_FEnsureHqCb(HQ *phq, long cb, long cbMinGrow, long *pcb);
+    bool _FEnsureHqCb(HQ *phq, long cb, long cbMinGrow, long *pcb);
 
   protected:
     long _cbMinGrow1;

--- a/kauai/SRC/SNDAMPRI.H
+++ b/kauai/SRC/SNDAMPRI.H
@@ -118,7 +118,7 @@ class CAMS : public CAMS_PAR
 
   public:
     ~CAMS(void);
-    static PCAMS CAMS::PcamsNewLoop(PCAMS pcamsSrc, long cactPlay);
+    static PCAMS PcamsNewLoop(PCAMS pcamsSrc, long cactPlay);
 
     IAMSound *psnd; // the sound to use
 

--- a/kauai/TOOLS/CHDOC.H
+++ b/kauai/TOOLS/CHDOC.H
@@ -574,7 +574,7 @@ class DCGB : public DCGB_PAR
     void _DeleteIv(long iv);
 
   public:
-    static void DCGB::InvalAllDcgb(PDOCB pdocb, PGRPB pgrpb, long iv, long cvIns, long cvDel);
+    static void InvalAllDcgb(PDOCB pdocb, PGRPB pgrpb, long iv, long cvIns, long cvDel);
     virtual bool FCmdKey(PCMD_KEY pcmd);
     virtual void MouseDown(long xp, long yp, long cact, ulong grfcust);
 


### PR DESCRIPTION
fixes some findings
warning level 4 is currently disabled (due to mass of warnings)
C++14 consr char* literator force is disabled

prepares better compatibility with gcc and other compilers