### PR TITLE
Search current working directory for Microsoft Kids

### DIFF
--- a/inc/utest.h
+++ b/inc/utest.h
@@ -115,6 +115,7 @@ class APP : public APP_PAR
     STN _stnProductShort; // Short version of product name
     STN _stnUser;         // User's name
     long _sidProduct;
+    FNI _fniCurrentDir; // fni of current working directory
     FNI _fniExe;        // fni of this executable file
     FNI _fniMsKidsDir;  // e.g., \mskids
     FNI _fniUsersDir;   // e.g., \mskids\users
@@ -157,6 +158,7 @@ class APP : public APP_PAR
     bool _FFindProductDir(PGST pgst);
     bool _FQueryProductExists(STN *pstnLong, STN *pstnShort, FNI *pfni);
     bool _FFindMsKidsDir(void);
+    bool _FFindMsKidsDirAt(FNI *path);
     bool _FCantFindFileDialog(PSTN pstn);
     bool _FGenericError(PSTZ message);
     bool _FGenericError(PSTN message);


### PR DESCRIPTION
With this patch, it is no longer necessary to copy the built exe to a new directory in order to start debugging. The program will now search the current working directory for "Microsoft Kids" if it isn't found in the exe's directory.

In the debugger settings, simply set the Working Directory to the folder containing "Microsoft Kids" and you're ready to go.