### PR TITLE
Fix warning C4291

### DIFF
--- a/kauai/src/base.cpp
+++ b/kauai/src/base.cpp
@@ -256,6 +256,7 @@ void *BASE::operator new(size_t cb)
 }
 
 #if defined(DEBUG) || defined(WIN)
+
 /***************************************************************************
     DEBUG : Unlink from linked list of allocated objects and free the memory.
 ***************************************************************************/
@@ -278,6 +279,14 @@ void BASE::operator delete(void *pv)
     ::delete (pv);
 #endif //! WIN
 }
+
+#ifdef DEBUG
+void BASE::operator delete(void *pv, schar *pszsFile, long lwLine)
+{
+    BASE::operator delete(pv);
+}
+#endif // DEBUG
+
 #endif // DEBUG || WIN
 
 #ifdef DEBUG

--- a/kauai/src/base.h
+++ b/kauai/src/base.h
@@ -235,6 +235,7 @@ class BASE
   public:
 #ifdef DEBUG
     void *operator new(size_t cb, schar *pszsFile, long lwLine);
+    void operator delete(void *pv, schar *pszsFile, long lwLine); // To prevent warning C4291
     void operator delete(void *pv);
     void MarkMemStub(void);
 #else //! DEBUG


### PR DESCRIPTION
This makes no difference to the compiled program, but about 340 warnings no longer appear.