### PR TITLE
Add stub implementation of AudioMan library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ endif()
 include(CMakeDependentOption)
 include(TargetChompSources)
 
-find_package(AudioMan REQUIRED)
+if ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
+  find_package(AudioMan REQUIRED)
+endif()
 find_package(BRender REQUIRED)
 
 # Options
@@ -60,6 +62,19 @@ target_include_directories(kcdc-386 PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRE
 add_executable(kcd2-386 EXCLUDE_FROM_ALL)
 target_sources(kcd2-386 PRIVATE "${PROJECT_SOURCE_DIR}/kauai/src/kcd2_386.c")
 target_include_directories(kcd2-386 PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)
+
+if ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
+  set(AUDIOMAN_LIB 3DMMForever::AudioMan)
+else()
+  add_library(audioman)
+  target_include_directories(audioman PUBLIC
+      "${PROJECT_SOURCE_DIR}/kauai/src"
+  )
+  target_sources(audioman PRIVATE
+      "${PROJECT_SOURCE_DIR}/audioman/audioman.cpp"
+  )
+  set(AUDIOMAN_LIB audioman)
+endif()
 
 add_executable(chelp WIN32 EXCLUDE_FROM_ALL)
 target_sources(chelp PRIVATE
@@ -244,7 +259,7 @@ target_compile_definitions(kauai PUBLIC
 
 target_link_libraries(kauai
   PUBLIC
-    3DMMForever::AudioMan
+    "${AUDIOMAN_LIB}"
     $<$<PLATFORM_ID:Windows>:Msacm32>
     $<$<PLATFORM_ID:Windows>:Vfw32>
     $<$<PLATFORM_ID:Windows>:Winmm>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,7 @@ endif()
 include(CMakeDependentOption)
 include(TargetChompSources)
 
-if ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
-  find_package(AudioMan REQUIRED)
-endif()
+find_package(AudioMan)
 find_package(BRender REQUIRED)
 
 # Options
@@ -63,17 +61,15 @@ add_executable(kcd2-386 EXCLUDE_FROM_ALL)
 target_sources(kcd2-386 PRIVATE "${PROJECT_SOURCE_DIR}/kauai/src/kcd2_386.c")
 target_include_directories(kcd2-386 PRIVATE $<TARGET_PROPERTY:kauai,INCLUDE_DIRECTORIES>)
 
-if ("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "Win32")
-  set(AUDIOMAN_LIB 3DMMForever::AudioMan)
-else()
+if (NOT TARGET 3DMMForever::AudioMan)
   add_library(audioman)
+  add_library(3DMMForever::AudioMan ALIAS audioman)
   target_include_directories(audioman PUBLIC
       "${PROJECT_SOURCE_DIR}/kauai/src"
   )
   target_sources(audioman PRIVATE
       "${PROJECT_SOURCE_DIR}/audioman/audioman.cpp"
   )
-  set(AUDIOMAN_LIB audioman)
 endif()
 
 add_executable(chelp WIN32 EXCLUDE_FROM_ALL)
@@ -259,7 +255,7 @@ target_compile_definitions(kauai PUBLIC
 
 target_link_libraries(kauai
   PUBLIC
-    "${AUDIOMAN_LIB}"
+    3DMMForever::AudioMan
     $<$<PLATFORM_ID:Windows>:Msacm32>
     $<$<PLATFORM_ID:Windows>:Vfw32>
     $<$<PLATFORM_ID:Windows>:Winmm>

--- a/audioman/audioman.cpp
+++ b/audioman/audioman.cpp
@@ -1,0 +1,59 @@
+// Implementation of the AudioMan library.
+// Created for 3DMMForever.
+// FIXME: This is a nonworking stub.
+
+#include <Windows.h>
+#include <initguid.h>
+
+#include "AUDIOMAN.H"
+
+STDAPI AllocSoundFromStream(LPSOUND FAR* ppSound, LPSTREAM pStream, BOOL fSpooled, LPCACHECONFIG lpCacheConfig)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI AllocSoundFromFile(LPSOUND FAR* ppSound, char FAR* szFileName, DWORD dwOffset, BOOL fSpooled,
+	LPCACHECONFIG lpCacheConfig)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI AllocSoundFromMemory(LPSOUND FAR* ppSound, LPBYTE lpFileData, DWORD dwSize)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI_(LPMIXER) GetAudioManMixer(void)
+{
+	return NULL;
+}
+
+STDAPI AllocTrimFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI AllocBiasFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI AllocLoopFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc, DWORD dwLoops)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI AllocConvertFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc, LPWAVEFORMATEX lpwfx)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI SoundToFileAsWave(LPSOUND pSound, char FAR* pAbsFilePath)
+{
+	return E_NOTIMPL;
+}
+
+STDAPI_(int) DetectLeaks(BOOL fDebugOut, BOOL fMessageBox)
+{
+	return 0;
+}

--- a/audioman/audioman.cpp
+++ b/audioman/audioman.cpp
@@ -1,59 +1,59 @@
 // Implementation of the AudioMan library.
 // Created for 3DMMForever.
-// FIXME: This is a nonworking stub.
+// FIXME: This is a nonworking stub. The game will still function, but sound effects will be missing.
 
 #include <Windows.h>
 #include <initguid.h>
 
-#include "AUDIOMAN.H"
+#include "audioman.h"
 
-STDAPI AllocSoundFromStream(LPSOUND FAR* ppSound, LPSTREAM pStream, BOOL fSpooled, LPCACHECONFIG lpCacheConfig)
+STDAPI AllocSoundFromStream(LPSOUND FAR *ppSound, LPSTREAM pStream, BOOL fSpooled, LPCACHECONFIG lpCacheConfig)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
-STDAPI AllocSoundFromFile(LPSOUND FAR* ppSound, char FAR* szFileName, DWORD dwOffset, BOOL fSpooled,
-	LPCACHECONFIG lpCacheConfig)
+STDAPI AllocSoundFromFile(LPSOUND FAR *ppSound, char FAR *szFileName, DWORD dwOffset, BOOL fSpooled,
+                          LPCACHECONFIG lpCacheConfig)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
-STDAPI AllocSoundFromMemory(LPSOUND FAR* ppSound, LPBYTE lpFileData, DWORD dwSize)
+STDAPI AllocSoundFromMemory(LPSOUND FAR *ppSound, LPBYTE lpFileData, DWORD dwSize)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
 STDAPI_(LPMIXER) GetAudioManMixer(void)
 {
-	return NULL;
+    return NULL;
 }
 
-STDAPI AllocTrimFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc)
+STDAPI AllocTrimFilter(LPSOUND FAR *ppSound, LPSOUND pSoundSrc)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
-STDAPI AllocBiasFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc)
+STDAPI AllocBiasFilter(LPSOUND FAR *ppSound, LPSOUND pSoundSrc)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
-STDAPI AllocLoopFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc, DWORD dwLoops)
+STDAPI AllocLoopFilter(LPSOUND FAR *ppSound, LPSOUND pSoundSrc, DWORD dwLoops)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
-STDAPI AllocConvertFilter(LPSOUND FAR* ppSound, LPSOUND pSoundSrc, LPWAVEFORMATEX lpwfx)
+STDAPI AllocConvertFilter(LPSOUND FAR *ppSound, LPSOUND pSoundSrc, LPWAVEFORMATEX lpwfx)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
-STDAPI SoundToFileAsWave(LPSOUND pSound, char FAR* pAbsFilePath)
+STDAPI SoundToFileAsWave(LPSOUND pSound, char FAR *pAbsFilePath)
 {
-	return E_NOTIMPL;
+    return E_NOTIMPL;
 }
 
 STDAPI_(int) DetectLeaks(BOOL fDebugOut, BOOL fMessageBox)
 {
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
This PR adds a nonfunctional stub implementation of the AudioMan library. The new AudioMan is only used for non-Win32-x86 platforms, otherwise the original library is linked.