### PR TITLE
Simple fix for a bug when saving

### DIFF
--- a/kauai/src/docb.cpp
+++ b/kauai/src/docb.cpp
@@ -236,7 +236,7 @@ tribool DOCB::_TQuerySave(bool fForce)
 {
     AssertThis(0);
 
-    return vpappb->TQuerySaveDoc(this, fForce) ? tYes : tNo;
+    return vpappb->TQuerySaveDoc(this, fForce);
 }
 
 /***************************************************************************


### PR DESCRIPTION
Bug was introduced in 185972e46fbc46ed12e9b8a97d09fea869f17ebc. When querying save changes before exiting the app, if the user chooses "keep working, save later" the game would just quit and save changes.